### PR TITLE
Prototype pollution fix - Checking magic attributes

### DIFF
--- a/lib/conflate.js
+++ b/lib/conflate.js
@@ -10,6 +10,15 @@ function applyConversion(key, value, conversions, whitelist, ignoreKeys) {
   return value;
 }
 
+/**
+ * Returns true, if given key is included in the blacklisted
+ * keys.
+ * @param key key for check, string.
+ */
+function isPrototypePolluted(key) {
+  return ['__proto__', 'prototype', 'constructor'].includes(key);
+}
+
 function merge(obj1, obj2, conversions, whitelist, ignoreKeys) {
   if (typeof obj2 !== 'object' || !obj2) {
     return;
@@ -18,7 +27,7 @@ function merge(obj1, obj2, conversions, whitelist, ignoreKeys) {
   const keys = Object.keys(obj2);
   for (let i = 0; i < keys.length; i++) {
     const k = keys[i];
-    if (whitelist.length && whitelist.indexOf(k) === -1) {
+    if (whitelist.length && whitelist.indexOf(k) === -1 || isPrototypePolluted(k)) {
       continue;
     }
     if (ignoreKeys.indexOf(k) === -1) {

--- a/test/conflate.test.js
+++ b/test/conflate.test.js
@@ -302,4 +302,16 @@ describe('Conflate', () => {
   //
   //
   it('applies conversions to nested objects');
+  //
+  //
+  it('prevent prototype pollution', () => {
+    const x = {};
+    const y = JSON.parse('{"__proto__": {"polluted": true}}');
+
+    const r = conflate(x, y);
+
+    expect(r.polluted).to.equal(undefined);
+    expect({}.polluted).to.not.equal(true);
+    expect({}.polluted).to.equal(undefined);
+  });
 });


### PR DESCRIPTION
### 📊 Metadata *

conflate is vulnerable to Prototype Pollution.


#### Bounty URL: https://www.huntr.dev/bounties/1-npm-conflate

### ⚙️ Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as proto, constructor and prototype.
An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.
Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### 💻 Technical Description *

Fixed by avoiding setting magical attributes. The bug is fixed by validating the input strArray to check for prototypes. It is implemented by a simple validation to check for prototype keywords (proto, constructor and prototype), where if it exists, the function returns the object without modifying it, thus fixing the Prototype Pollution Vulnerability.

### 🐛 Proof of Concept (PoC) *

Create the following PoC file:

```
// poc.js
const conflate = require('conflate')

console.log('Before: ', {}.polluted})
conflate({}, JSON.parse('{"__proto__": {"polluted": true}}'))
console.log('After: ', {}.polluted)
```

Execute the following commands in the terminal:

```
npm i conflate # install vulnerable package
node poc.js # run the PoC
```

Check the output:

```
Before: undefined
After: true
```

### 🔥 Proof of Fix (PoF) *

Before:

![image](https://user-images.githubusercontent.com/64132745/104119936-1c7bc400-5359-11eb-8f52-76c7c0ce7d5d.png)

After:

![image](https://user-images.githubusercontent.com/64132745/104119944-2c93a380-5359-11eb-8d2c-5e6f57134586.png)


### 👍 User Acceptance Testing (UAT)

![image](https://user-images.githubusercontent.com/64132745/104120920-89df2300-5360-11eb-9380-26a519d72792.png)


After the fix, functionality is unaffected.

### 🔗 Relates to...

_Provide the URL of the PR for the disclosure that this fix relates to._
